### PR TITLE
success pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,5 +14,5 @@ jobs:
     - uses: actions/setup-python@v2
     - name: configure
       run: |
-        cmake -H. -Bbuild -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DUSE_CPM=ON
+        cmake -H. -Bbuild -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DUSE_CPM=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - uses: pre-commit/action@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ CMakeUserPresets.json
 build/
 html/
 lectures/
+venv/
 
 ################################
 ############ C/C++ #############

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.3.5
     hooks:
       - id: clang-tidy
-        args: ['--', '-Ibuild/_deps/json-src/include', '-Ibuild/_deps/cxxopts-src/include', '-Ibuild/_deps/fmt-src/include', '-Ibuild/_deps/spdlog-src/include', '-Ibuild/configured_files/include', '-Isrc/my_lib']
+        args: ['-config-file=.clang-tidy', '-p=build']
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v16.0.2'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.3.5
     hooks:
       - id: clang-tidy
-        args: ['--', '-Ibuild/_deps/json-src/include']
+        args: ['--', '-Ibuild/_deps/json-src/include', '-Ibuild/_deps/cxxopts-src/include', '-Ibuild/_deps/fmt-src/include', '-Ibuild/_deps/spdlog-src/include', '-Ibuild/configured_files/include', '-Isrc/my_lib']
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v16.0.2'


### PR DESCRIPTION
I added a configure step in pre-commit workflow and set clang-tidy to use the build/compile_commands.json. Now pre-commit actions runs successfully.